### PR TITLE
Add VulkanCTS, xml and build dirs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 _generated-skeletons
+VulkanCTS
+xml
+spirv-to-alloy/build


### PR DESCRIPTION
These folders are generated during the build and
running process, so they do not need to be tracked.