### PR TITLE
Make the Alloy validity check optional in spirv-to-alloy

### DIFF
--- a/spirv-to-alloy/src/spirv_to_alloy/src/main.cc
+++ b/spirv-to-alloy/src/spirv_to_alloy/src/main.cc
@@ -68,12 +68,24 @@ uint32_t LogBase2(uint32_t arg) {
 
 } // namespace
 
+void print_usage_warning(const char **argv) {
+  std::cerr << "Usage: " << argv[0] << " <spirv-binary> <function-id> <alloy-module-name> [skip-validation]" << std::endl;
+}
+
 int main(int argc, const char **argv) {
 
-  if (argc != 4) {
-    std::cerr << "Usage: " << argv[0] << " <spirv-binary> <function-id> <alloy-module-name>"
-              << std::endl;
+  if (argc < 4 || argc > 5) {
+    print_usage_warning(argv);
     return 1;
+  }
+
+  bool skip_validation = false;
+  if (argc == 5) {
+    if (std::string(argv[4]).compare(std::string("skip-validation")) != 0) {
+      print_usage_warning(argv);
+      return 1;
+    }
+    skip_validation = true;
   }
 
   std::string input_filename(argv[1]);
@@ -288,7 +300,13 @@ int main(int argc, const char **argv) {
   }
   std::cout << "  }" << std::endl;
   std::cout << "}" << std::endl;
-  std::cout << "run { sampleCFG && validCFG/Valid } for " << std::to_string(num_blocks) << " Block";
+
+  std::string validation_check("&& validCFG/Valid ");
+  if (skip_validation) {
+      validation_check = "";
+  }
+
+  std::cout << "run { sampleCFG " << validation_check << "} for " << std::to_string(num_blocks) << " Block";
   if (max_switch_targets > 4) {
     std::cout << ", " << max_switch_targets << " seq";
   }


### PR DESCRIPTION
- Avoid outputting the validCFG/Valid check in the Alloy
  output of spirv-to-alloy if skip-validation is passed
  as an argument. This makes .asm to .als conversion much
  faster in the case where we already know that a .asm
  file contains a valid CFG.

- Add a skip-validation argument to scrape-vulkan-cts.py
  so that .als files can be generated within ~10 mins
  instead of hours.